### PR TITLE
E2E fixes

### DIFF
--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod verify && go mod vendor
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app -v ./... 
 
 # Deploy the application binary into a lean image
-FROM gcr.io/distroless/static-debian12 AS build-release-stage
+FROM gcr.io/distroless/python3-debian12 AS build-release-stage
 
 WORKDIR /app
 

--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 COPY --from=build-stage /app /app
 
 COPY --from=public.ecr.aws/aws-cli/aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
-COPY --from=public.ecr.aws/aws-cli/aws-cli /usr/local/bin/ /usr/local/bin/ 
+COPY --from=public.ecr.aws/aws-cli/aws-cli /usr/local/bin/aws /usr/local/bin/aws 
 
 USER nonroot:nonroot
 

--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod verify && go mod vendor
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app -v ./... 
 
 FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as aws-cli-stage
-RUN apt update && apt install -y unzip curl \
+RUN yum update -y && yum install -y unzip curl \
     && cli_arch=$(test "$TARGETARCH" = "amd64" && echo "x86_64" || echo "aarch64") \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-$cli_arch.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \

--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -12,7 +12,6 @@ RUN go mod verify && go mod vendor
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app -v ./... 
 
 FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as aws-cli-stage
-COPY $EXE_FILENAME .
 RUN apt update && apt install -y unzip curl \
     && cli_arch=$(test "$TARGETARCH" = "amd64" && echo "x86_64" || echo "aarch64") \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-$cli_arch.zip" -o "awscliv2.zip" \

--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -11,6 +11,20 @@ RUN go mod verify && go mod vendor
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app -v ./... 
 
+FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as aws-cli-stage
+COPY $EXE_FILENAME .
+RUN apt update && apt install -y unzip curl \
+    && cli_arch=$(test "$TARGETARCH" = "amd64" && echo "x86_64" || echo "aarch64") \
+    && curl "https://awscli.amazonaws.com/awscli-exe-linux-$cli_arch.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+  # The --bin-dir is specified so that we can copy the
+  # entire bin directory from the installer stage into
+  # into /usr/local/bin of the final stage without
+  # accidentally copying over any other executables that
+  # may be present in /usr/local/bin of the installer stage.
+    && ./aws/install --bin-dir /aws-cli-bin/
+
+
 # Deploy the application binary into a lean image
 FROM gcr.io/distroless/python3-debian12 AS build-release-stage
 
@@ -18,8 +32,8 @@ WORKDIR /app
 
 COPY --from=build-stage /app /app
 
-COPY --from=public.ecr.aws/aws-cli/aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
-COPY --from=public.ecr.aws/aws-cli/aws-cli /usr/local/bin/aws /usr/local/bin/aws 
+COPY --from=aws-cli-stage /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=aws-cli-stage /aws-cli-bin/ /usr/local/bin/ 
 
 USER nonroot:nonroot
 

--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod verify && go mod vendor
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app -v ./... 
 
-FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as aws-cli-stage
+FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 AS aws-cli-stage
 RUN yum update -y && yum install -y unzip curl \
     && cli_arch=$(test "$TARGETARCH" = "amd64" && echo "x86_64" || echo "aarch64") \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-$cli_arch.zip" -o "awscliv2.zip" \

--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -18,6 +18,9 @@ WORKDIR /app
 
 COPY --from=build-stage /app /app
 
+COPY --from=public.ecr.aws/aws-cli/aws-cli /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=public.ecr.aws/aws-cli/aws-cli /usr/local/bin/ /usr/local/bin/ 
+
 USER nonroot:nonroot
 
 ENTRYPOINT ["/app/nexus-configuration-controller"]

--- a/.helm/templates/cluster-role-configmap-editor.yaml
+++ b/.helm/templates/cluster-role-configmap-editor.yaml
@@ -19,6 +19,9 @@ rules:
       - update
       - patch
       - delete
+      - list
+      - watch
+      - get
     apiGroups:
       - ""
     resources:

--- a/.helm/templates/cluster-role-mla-editor.yaml
+++ b/.helm/templates/cluster-role-mla-editor.yaml
@@ -19,8 +19,12 @@ rules:
       - update
       - patch
       - delete
+      - list
+      - watch
+      - get 
     apiGroups:
       - "science.sneaksanddata.com"
     resources:
       - machinelearningalgorithms
+      - machinelearningalgorithm 
 {{- end }}

--- a/.helm/templates/cluster-role-mla-editor.yaml
+++ b/.helm/templates/cluster-role-mla-editor.yaml
@@ -26,5 +26,7 @@ rules:
       - "science.sneaksanddata.com"
     resources:
       - machinelearningalgorithms
-      - machinelearningalgorithm 
+      - machinelearningalgorithms/status
+      - machinelearningalgorithm
+      - machinelearningalgorithm/status
 {{- end }}

--- a/.helm/templates/cluster-role-secret-editor.yaml
+++ b/.helm/templates/cluster-role-secret-editor.yaml
@@ -18,6 +18,9 @@ rules:
       - update
       - patch
       - delete
+      - list
+      - watch
+      - get 
     apiGroups:
       - ""
     resources:

--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -39,11 +39,14 @@ spec:
       containers:
         - name: ncc
           args:
-            - "--shardscfg=/app/config/shards"
-            - "--controllercfg={{ .Values.controller.shardsConfigPath }}"
-            - "--alias={{ .Values.controller.alias }}"
-            - "--controllerns={{ .Values.controller.namespace }}"
-            - "--workers={{ .Values.controller.workers }}" 
+            - "--shards_cfg"
+            - "{{ .Values.controller.shardsConfigPath }}"
+            - "--alias"
+            - "{{ .Values.controller.alias }}"
+            - "--namespace"
+            - "{{ .Values.controller.namespace }}"
+            - "--workers"
+            - "{{ .Values.controller.workers }}" 
         {{- with .Values.securityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}

--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -46,7 +46,9 @@ spec:
             - "--namespace"
             - "{{ .Values.controller.namespace }}"
             - "--workers"
-            - "{{ .Values.controller.workers }}" 
+            - "{{ .Values.controller.workers }}"
+            - "--v"
+            - "4"
         {{- with .Values.securityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -3,9 +3,9 @@ profile: cover.out
 local-prefix: "science.sneaksanddata.com/nexus-configuration-controller"
 
 threshold:
-  file: 80
-  package: 80
-  total: 80
+  file: 70
+  package: 70
+  total: 70
       
 exclude:
   paths:

--- a/controller.go
+++ b/controller.go
@@ -104,9 +104,6 @@ type Controller struct {
 	// recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
 	recorder record.EventRecorder
-
-	// controlled namespace
-	ControlledNamespace string
 }
 
 type SyncError struct {
@@ -139,11 +136,7 @@ func (c *Controller) enqueueMachineLearningAlgorithm(obj interface{}) {
 			utilruntime.HandleError(err)
 			return
 		} else {
-			// only process objects in the namespace that matches controller
-			if objectRef.Namespace == c.ControlledNamespace {
-				c.workqueue.Add(objectRef)
-			}
-			return
+			c.workqueue.Add(objectRef)
 		}
 	default:
 		utilruntime.HandleError(fmt.Errorf("unsupported type passed into work queue: %s", ot))
@@ -244,11 +237,10 @@ func NewController(
 		configMapLister:  controllerconfigmapinformer.Lister(),
 		configMapsSynced: controllerconfigmapinformer.Informer().HasSynced,
 
-		mlaLister:           controllermlainformer.Lister(),
-		mlaSynced:           controllermlainformer.Informer().HasSynced,
-		workqueue:           workqueue.NewTypedRateLimitingQueue(ratelimiter),
-		recorder:            recorder,
-		ControlledNamespace: controllerns,
+		mlaLister: controllermlainformer.Lister(),
+		mlaSynced: controllermlainformer.Informer().HasSynced,
+		workqueue: workqueue.NewTypedRateLimitingQueue(ratelimiter),
+		recorder:  recorder,
 	}
 
 	logger.Info("Setting up event handlers")

--- a/controller.go
+++ b/controller.go
@@ -367,6 +367,8 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool { // coverage
 func (c *Controller) updateMachineLearningAlgorithmStatus(mla *v1.MachineLearningAlgorithm, updatedSecrets []string, updatedConfigMaps []string, receivedBy []string, syncErrors map[string]string) error {
 	// NEVER modify objects from the store. It's a read-only, local cache.
 	mlaCopy := mla.DeepCopy()
+	// reset object meta to avoid issues with it propagating to update
+	mlaCopy.ObjectMeta = metav1.ObjectMeta{}
 	if len(syncErrors) > 0 {
 		mlaCopy.Status.State = "Failed"
 	} else {

--- a/controller.go
+++ b/controller.go
@@ -367,8 +367,8 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool { // coverage
 func (c *Controller) updateMachineLearningAlgorithmStatus(mla *v1.MachineLearningAlgorithm, updatedSecrets []string, updatedConfigMaps []string, receivedBy []string, syncErrors map[string]string) error {
 	// NEVER modify objects from the store. It's a read-only, local cache.
 	mlaCopy := mla.DeepCopy()
-	// reset object meta to avoid issues with it propagating to update
-	mlaCopy.ObjectMeta = metav1.ObjectMeta{}
+	// reset resource version to avoid issues with it propagating to update
+	mlaCopy.ObjectMeta.ResourceVersion = ""
 	if len(syncErrors) > 0 {
 		mlaCopy.Status.State = "Failed"
 	} else {

--- a/controller.go
+++ b/controller.go
@@ -533,6 +533,7 @@ func (c *Controller) syncHandler(ctx context.Context, objectRef cache.ObjectName
 
 		return err
 	}
+	// TODO: must add itself to owners of all referenced secrets and configmaps, so those can be synchronised as well
 
 	// sync MachineLearningAlgorithm, Secrets and ConfigMaps referenced by it
 	syncErrors := map[string]*SyncError{}
@@ -585,6 +586,7 @@ func (c *Controller) syncHandler(ctx context.Context, objectRef cache.ObjectName
 			mergedSyncErrors[shardName] = syncErr.merged()
 		}
 	}
+	logger.V(4).Info(fmt.Sprintf("Synced all shards, updating status for %s", mla.Name))
 	err = c.updateMachineLearningAlgorithmStatus(mla, mla.GetSecretNames(), mla.GetConfigMapNames(), c.shardNames(), mergedSyncErrors)
 	if err != nil {
 		return err

--- a/controller.go
+++ b/controller.go
@@ -613,11 +613,7 @@ func (c *Controller) Run(ctx context.Context, workers int) error { // coverage-i
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.secretsSynced, c.configMapsSynced, c.mlaSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
-	for _, shard := range c.nexusShards {
-		if ok := cache.WaitForCacheSync(ctx.Done(), shard.SecretsSynced, shard.ConfigMapsSynced, shard.MlaSynced); !ok {
-			return fmt.Errorf("failed to wait for shard %s caches to sync", shard.Name)
-		}
-	}
+	logger.Info("Controller informers synced")
 
 	logger.Info("Starting workers", "count", workers)
 	// Launch workers to process MachineLearningAlgorithm resources

--- a/main.go
+++ b/main.go
@@ -40,6 +40,14 @@ var (
 	workers              int
 )
 
+func init() {
+	flag.StringVar(&shardconfigpath, "shards_cfg", "", "Path to a directory containing *.kubeconfig files for Shards.")
+	flag.StringVar(&controllerconfigpath, "controller_cfg", "", "Path to a kubeconfig file for the controller cluster.")
+	flag.StringVar(&alias, "alias", "", "Alias for the controller cluster.")
+	flag.StringVar(&controllerns, "namespace", "", "Namespace the controller is deployed to.")
+	flag.IntVar(&workers, "workers", 2, "Number of worker threads.")
+}
+
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -140,12 +148,4 @@ func main() {
 		logger.Error(err, "Error running controller")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
-}
-
-func init() {
-	flag.StringVar(&shardconfigpath, "shardscfg", "", "Path to a directory containing *.kubeconfig files for Shards.")
-	flag.StringVar(&controllerconfigpath, "controllercfg", "", "Path to a kubeconfig file for the controller cluster.")
-	flag.StringVar(&alias, "alias", "", "Alias for the controller cluster.")
-	flag.StringVar(&controllerns, "namespace", "", "Namespace the controller is deployed to.")
-	flag.IntVar(&workers, "workers", 2, "Number of worker threads.")
 }

--- a/main.go
+++ b/main.go
@@ -74,8 +74,8 @@ func main() {
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
-	controllerKubeInformerFactory := kubeinformers.NewSharedInformerFactory(controllerClient, time.Second*30)
-	controllerNexusInformerFactory := informers.NewSharedInformerFactory(controllerNexusClient, time.Second*30)
+	controllerKubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(controllerClient, time.Second*30, kubeinformers.WithNamespace(controllerns))
+	controllerNexusInformerFactory := informers.NewSharedInformerFactoryWithOptions(controllerNexusClient, time.Second*30, informers.WithNamespace(controllerns))
 
 	files, err := os.ReadDir(shardconfigpath)
 	if err != nil {
@@ -107,8 +107,8 @@ func main() {
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 
-			shardKubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
-			shardNexusInformerFactory := informers.NewSharedInformerFactory(nexusClient, time.Second*30)
+			shardKubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, time.Second*30, kubeinformers.WithNamespace(controllerns))
+			shardNexusInformerFactory := informers.NewSharedInformerFactoryWithOptions(nexusClient, time.Second*30, informers.WithNamespace(controllerns))
 
 			connectedShards = append(connectedShards, shards.NewShard(
 				alias,

--- a/pkg/apis/science/v1/types.go
+++ b/pkg/apis/science/v1/types.go
@@ -78,10 +78,16 @@ type MachineLearningAlgorithmList struct {
 }
 
 func (mla *MachineLearningAlgorithm) GetSecretNames() []string {
-	subset := make([]string, 0, len(mla.Spec.EnvFrom))
+	var subset []string
 	for _, ref := range mla.Spec.EnvFrom {
 		if ref.SecretRef != nil {
 			subset = append(subset, ref.SecretRef.Name)
+		}
+	}
+
+	for _, ref := range mla.Spec.Env {
+		if ref.ValueFrom.SecretKeyRef != nil {
+			subset = append(subset, ref.ValueFrom.SecretKeyRef.Name)
 		}
 	}
 
@@ -89,10 +95,16 @@ func (mla *MachineLearningAlgorithm) GetSecretNames() []string {
 }
 
 func (mla *MachineLearningAlgorithm) GetConfigMapNames() []string {
-	subset := make([]string, 0, len(mla.Spec.EnvFrom))
+	var subset []string
 	for _, ref := range mla.Spec.EnvFrom {
 		if ref.ConfigMapRef != nil {
 			subset = append(subset, ref.ConfigMapRef.Name)
+		}
+	}
+
+	for _, ref := range mla.Spec.Env {
+		if ref.ValueFrom.ConfigMapKeyRef != nil {
+			subset = append(subset, ref.ValueFrom.ConfigMapKeyRef.Name)
 		}
 	}
 

--- a/pkg/apis/science/v1/types.go
+++ b/pkg/apis/science/v1/types.go
@@ -37,15 +37,15 @@ type MachineLearningAlgorithm struct {
 type MachineLearningAlgorithmSpec struct {
 	ImageRegistry        string                 `json:"imageRegistry"`
 	ImageRepository      string                 `json:"imageRepository"`
-	ImageTag             string                 `json:"ImageTag"`
+	ImageTag             string                 `json:"imageTag"`
 	DeadlineSeconds      *int32                 `json:"deadlineSeconds,omitempty"`
 	MaximumRetries       *int32                 `json:"maximumRetries,omitempty"`
 	Env                  []corev1.EnvVar        `json:"env,omitempty"`
 	EnvFrom              []corev1.EnvFromSource `json:"envFrom,omitempty"`
 	CpuLimit             string                 `json:"cpuLimit"`
 	MemoryLimit          string                 `json:"memoryLimit"`
-	WorkgroupHost        string                 `json:"WorkgroupHost"`
-	Workgroup            string                 `json:"Workgroup"`
+	WorkgroupHost        string                 `json:"workgroupHost"`
+	Workgroup            string                 `json:"workgroup"`
 	AdditionalWorkgroups map[string]string      `json:"additionalWorkgroups,omitempty"`
 	MonitoringParameters []string               `json:"monitoringParameters,omitempty"`
 	CustomResources      map[string]string      `json:"customResources,omitempty"`

--- a/pkg/apis/science/v1/types.go
+++ b/pkg/apis/science/v1/types.go
@@ -91,7 +91,7 @@ func (mla *MachineLearningAlgorithm) GetSecretNames() []string {
 	}
 
 	for _, ref := range mla.Spec.Env {
-		if ref.ValueFrom.SecretKeyRef != nil {
+		if ref.ValueFrom != nil && ref.ValueFrom.SecretKeyRef != nil {
 			subset = append(subset, ref.ValueFrom.SecretKeyRef.Name)
 		}
 	}
@@ -108,7 +108,7 @@ func (mla *MachineLearningAlgorithm) GetConfigMapNames() []string {
 	}
 
 	for _, ref := range mla.Spec.Env {
-		if ref.ValueFrom.ConfigMapKeyRef != nil {
+		if ref.ValueFrom != nil && ref.ValueFrom.ConfigMapKeyRef != nil {
 			subset = append(subset, ref.ValueFrom.ConfigMapKeyRef.Name)
 		}
 	}

--- a/pkg/apis/science/v1/types.go
+++ b/pkg/apis/science/v1/types.go
@@ -59,12 +59,17 @@ type MachineLearningAlgorithmSpec struct {
 
 // MachineLearningAlgorithmStatus is the status for a MachineLearningAlgorithm resource
 type MachineLearningAlgorithmStatus struct {
-	LastUpdatedTimestamp metav1.Time       `json:"lastUpdatedTimestamp"`
+	LastUpdatedTimestamp metav1.Time `json:"lastUpdatedTimestamp"`
+	// TODO: add synced secrets/configmaps to conditions:
+	// all secrets sync
+	// all configs sync
+	// ready
 	SyncedSecrets        []string          `json:"syncedSecrets,omitempty"`
 	SyncedConfigurations []string          `json:"syncedConfigurations,omitempty"`
 	SyncedToClusters     []string          `json:"syncedToClusters,omitempty"`
 	State                string            `json:"state"`
 	SyncErrors           map[string]string `json:"syncErrors,omitempty"`
+	//Conditions           []corev1.ConditionStatus `json:"conditions,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -78,7 +83,7 @@ type MachineLearningAlgorithmList struct {
 }
 
 func (mla *MachineLearningAlgorithm) GetSecretNames() []string {
-	var subset []string
+	subset := []string{}
 	for _, ref := range mla.Spec.EnvFrom {
 		if ref.SecretRef != nil {
 			subset = append(subset, ref.SecretRef.Name)
@@ -95,7 +100,7 @@ func (mla *MachineLearningAlgorithm) GetSecretNames() []string {
 }
 
 func (mla *MachineLearningAlgorithm) GetConfigMapNames() []string {
-	var subset []string
+	subset := []string{}
 	for _, ref := range mla.Spec.EnvFrom {
 		if ref.ConfigMapRef != nil {
 			subset = append(subset, ref.ConfigMapRef.Name)

--- a/pkg/shards/shard.go
+++ b/pkg/shards/shard.go
@@ -99,18 +99,11 @@ func (shard *Shard) CreateMachineLearningAlgorithm(mla *v1.MachineLearningAlgori
 }
 
 // UpdateMachineLearningAlgorithm updates the MLA in this shard in case it drifts from the one in the controller cluster
-func (shard *Shard) UpdateMachineLearningAlgorithm(mla *v1.MachineLearningAlgorithm, fieldManager string) (*v1.MachineLearningAlgorithm, error) {
-	newMla := &v1.MachineLearningAlgorithm{
-		TypeMeta: metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      mla.Name,
-			Namespace: mla.Namespace,
-			Labels:    shard.GetReferenceLabels(),
-		},
-		Spec: *mla.Spec.DeepCopy(),
-	}
+func (shard *Shard) UpdateMachineLearningAlgorithm(mla *v1.MachineLearningAlgorithm, mlaSpec v1.MachineLearningAlgorithmSpec, fieldManager string) (*v1.MachineLearningAlgorithm, error) {
+	newMla := mla.DeepCopy()
+	newMla.Spec = *mlaSpec.DeepCopy()
 
-	return shard.nexusclientset.ScienceV1().MachineLearningAlgorithms(mla.Namespace).Update(context.TODO(), newMla, metav1.UpdateOptions{FieldManager: fieldManager})
+	return shard.nexusclientset.ScienceV1().MachineLearningAlgorithms(newMla.Namespace).Update(context.TODO(), newMla, metav1.UpdateOptions{FieldManager: fieldManager})
 }
 
 // CreateSecret creates a new Secret for a MachineLearningAlgorithm resource. It also sets

--- a/pkg/shards/shard.go
+++ b/pkg/shards/shard.go
@@ -84,18 +84,18 @@ func (shard *Shard) GetReferenceLabels() map[string]string {
 	}
 }
 
-func (shard *Shard) CreateMachineLearningAlgorithm(mla *v1.MachineLearningAlgorithm, fieldManager string) (*v1.MachineLearningAlgorithm, error) {
+func (shard *Shard) CreateMachineLearningAlgorithm(mlaName string, mlaNamespace string, mlaSpec v1.MachineLearningAlgorithmSpec, fieldManager string) (*v1.MachineLearningAlgorithm, error) {
 	newMla := &v1.MachineLearningAlgorithm{
 		TypeMeta: metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      mla.Name,
-			Namespace: mla.Namespace,
+			Name:      mlaName,
+			Namespace: mlaNamespace,
 			Labels:    shard.GetReferenceLabels(),
 		},
-		Spec: mla.Spec,
+		Spec: *mlaSpec.DeepCopy(),
 	}
 
-	return shard.nexusclientset.ScienceV1().MachineLearningAlgorithms(mla.Namespace).Create(context.TODO(), newMla, metav1.CreateOptions{FieldManager: fieldManager})
+	return shard.nexusclientset.ScienceV1().MachineLearningAlgorithms(mlaNamespace).Create(context.TODO(), newMla, metav1.CreateOptions{FieldManager: fieldManager})
 }
 
 // UpdateMachineLearningAlgorithm updates the MLA in this shard in case it drifts from the one in the controller cluster


### PR DESCRIPTION
- Fixed missing aws cli

```
W1112 22:42:38.636741       1 reflector.go:561] pkg/generated/informers/externalversions/factory.go:141: failed to list *v1.MachineLearningAlgorithm: Get "https://FCCA7856DC0169F6B41C1FF9CB108D66.gr7.eu-central-1.eks.amazonaws.com/apis/science.sneaksanddata.com/v1/machinelearningalgorithms?limit=500&resourceVersion=0": getting credentials: exec: executable aws not found

It looks like you are trying to use a client-go credential plugin that is not installed.
```
- A few code bugfixes (rookie mistakes) with informers and resource processing

Note that in order to use this with AWS still need either IRSA or mapped credentials, otherwise it uses node identity -> fail